### PR TITLE
Add DAO execute forwarding

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,23 +64,16 @@ pub trait DataCoalition:
         self.configure_staking(&dao, native_token, stake_lock_time);
     }
 
-    // #[payable("*")]
-    // #[endpoint(execute)]
-    // fn execute_endpoint(&self, destination: ManagedAddress, endpoint: ManagedBuffer) {
-    //     self.require_caller_is_dao();
-    //     let egld_value = self.call_value().egld_value().clone_value();
-    //     let transfers = self.call_value().all_esdt_transfers();
+    #[payable("*")]
+    #[endpoint(execute)]
+    fn execute_endpoint(&self, actions: MultiValueManagedVec<dao::Action<Self::Api>>) {
+        self.require_caller_is_dao();
+        let caller = self.blockchain().get_caller();
+        let value = self.call_value().egld_value().clone_value();
+        let transfers = self.call_value().all_esdt_transfers().clone_value();
 
-    //     let mut call = self.send().contract_call::<()>(destination, endpoint);
-
-    //     call.push_raw_argument()
-
-    //     if egld_value > 0 {
-    //         call.with_egld_transfer(egld_value).transfer_execute();
-    //     }
-
-    //     call.with_multi_token_transfer(transfers.clone_value()).transfer_execute();
-    // }
+        self.forward_execution(caller, actions, value, transfers);
+    }
 
     #[payable("*")]
     #[endpoint(grantAccess)]

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -5,14 +5,12 @@
 ////////////////////////////////////////////////////
 
 // Init:                                 1
-// Endpoints:                           25
+// Endpoints:                           26
 // Async Callback:                       1
-// Total number of exported functions:  27
+// Total number of exported functions:  28
 
 #![no_std]
-
-// Configuration that works with rustc < 1.73.0.
-// TODO: Recommended rustc version: 1.73.0 or newer.
+#![allow(internal_features)]
 #![feature(lang_items)]
 
 multiversx_sc_wasm_adapter::allocator!();
@@ -25,6 +23,7 @@ multiversx_sc_wasm_adapter::endpoints! {
         upgrade => upgrade
         create => create_endpoint
         createExternal => create_external_endpoint
+        execute => execute_endpoint
         grantAccess => grant_access_endpoint
         revokeAccess => revoke_access_endpoint
         getInfo => get_info_view


### PR DESCRIPTION
Allows the Data Coalition SC (which acts as the autocratic leader) to execute decisions agreed upon by the board, or other custom created roles within the DAO.

Fundamentally, an `execute` endpoint was added that serves as a proxy for the DAO to execute arbitrary actions.